### PR TITLE
feat: use dialog with backdrop to avoid weird interactions behind

### DIFF
--- a/src/components/svg/svg_editor.edit_form.tsx
+++ b/src/components/svg/svg_editor.edit_form.tsx
@@ -1,6 +1,6 @@
 import { offset, shift, useFloating } from '@floating-ui/react-dom';
 import type { MouseEvent, SubmitEvent } from 'react';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 import {
   AtomLabelEditButtonStyled,
@@ -22,7 +22,15 @@ export function AtomLabelEditForm(props: AtomLabelEditFormProps) {
   const { defaultValue, atomCoords, onSubmit, onCancel } = props;
   const floating = useFloating({
     placement: 'bottom-start',
-    middleware: [offset({ crossAxis: 5 }), shift({ crossAxis: true })],
+    strategy: 'absolute',
+    transform: false,
+    middleware: [
+      offset({ crossAxis: 5 }),
+      shift({
+        crossAxis: true,
+        altBoundary: true,
+      }),
+    ],
   });
   const formRef = useRef<HTMLFormElement>(null);
 
@@ -39,14 +47,6 @@ export function AtomLabelEditForm(props: AtomLabelEditFormProps) {
     event.stopPropagation();
     onCancel();
   }
-
-  useEffect(() => {
-    const dialog = floating.refs.floating.current as HTMLDialogElement | null;
-    if (!dialog) return;
-    if (dialog.open) return;
-
-    dialog.showModal();
-  }, [floating.refs.floating]);
 
   function onShortcut(event: MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
@@ -75,6 +75,11 @@ export function AtomLabelEditForm(props: AtomLabelEditFormProps) {
     onCancel();
   }
 
+  function onDialogRef(node: HTMLDialogElement | null) {
+    node?.showModal();
+    floating.refs.setFloating(node);
+  }
+
   return (
     <>
       {/* dom node for floating ui to hook on */}
@@ -89,8 +94,7 @@ export function AtomLabelEditForm(props: AtomLabelEditFormProps) {
 
       {/* The floating dialog (open at mount with `.showModal()`) */}
       <AtomLabelEditDialogStyled
-        // eslint-disable-next-line react-hooks/refs
-        ref={floating.refs.setFloating}
+        ref={onDialogRef}
         // eslint-disable-next-line react-hooks/refs
         style={floating.floatingStyles}
         closedby="any" // supports dismiss with `Escape` key

--- a/src/components/svg/svg_editor.edit_form.tsx
+++ b/src/components/svg/svg_editor.edit_form.tsx
@@ -1,0 +1,158 @@
+import { offset, shift, useFloating } from '@floating-ui/react-dom';
+import type { MouseEvent, SubmitEvent } from 'react';
+import { useEffect, useRef } from 'react';
+
+import {
+  AtomLabelEditButtonStyled,
+  AtomLabelEditDialogStyled,
+  AtomLabelEditFormStyled,
+  AtomLabelEditInputStyled,
+  greekLetters,
+  primes,
+} from './svg_editor.styled.ts';
+
+interface AtomLabelEditFormProps {
+  defaultValue: string;
+  atomCoords: { x: number; y: number };
+  onSubmit: (value: string) => void;
+  onCancel: () => void;
+}
+
+export function AtomLabelEditForm(props: AtomLabelEditFormProps) {
+  const { defaultValue, atomCoords, onSubmit, onCancel } = props;
+  const floating = useFloating({
+    placement: 'bottom-start',
+    middleware: [offset({ crossAxis: 5 }), shift({ crossAxis: true })],
+  });
+  const formRef = useRef<HTMLFormElement>(null);
+
+  function onFormSubmit(event: SubmitEvent<HTMLFormElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    const formData = new FormData(event.currentTarget);
+    const value = formData.get('label') as string;
+    onSubmit(value);
+  }
+
+  function onCancelClick(event: MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    onCancel();
+  }
+
+  useEffect(() => {
+    const dialog = floating.refs.floating.current as HTMLDialogElement | null;
+    if (!dialog) return;
+    if (dialog.open) return;
+
+    dialog.showModal();
+  }, [floating.refs.floating]);
+
+  function onShortcut(event: MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (!formRef.current) return;
+    const form = formRef.current;
+    const input = form.querySelector('input[type="text"]') as HTMLInputElement;
+    if (!input) return;
+
+    const value = event.currentTarget.textContent.trim();
+    input.setRangeText(
+      value,
+      input.selectionStart ?? 0,
+      input.selectionEnd ?? input.value.length,
+      'end',
+    );
+    input.focus();
+  }
+
+  function handleDialogLightDismiss(event: MouseEvent<HTMLDialogElement>) {
+    if (event.target !== floating.refs.floating.current) return;
+
+    // The dialog has no padding, if it is the target of the click,
+    // it means we click on the backdrop.
+    onCancel();
+  }
+
+  return (
+    <>
+      {/* dom node for floating ui to hook on */}
+      <span
+        ref={floating.refs.setReference}
+        style={{
+          position: 'absolute',
+          top: atomCoords.y,
+          left: atomCoords.x,
+        }}
+      />
+
+      {/* The floating dialog (open at mount with `.showModal()`) */}
+      <AtomLabelEditDialogStyled
+        // eslint-disable-next-line react-hooks/refs
+        ref={floating.refs.setFloating}
+        // eslint-disable-next-line react-hooks/refs
+        style={floating.floatingStyles}
+        closedby="any" // supports dismiss with `Escape` key
+        onClose={onCancel}
+        onClick={handleDialogLightDismiss}
+      >
+        <AtomLabelEditFormStyled
+          ref={formRef}
+          onSubmit={onFormSubmit}
+          method="dialog"
+        >
+          <AtomLabelEditInputStyled
+            type="text"
+            name="label"
+            defaultValue={defaultValue}
+            size={5}
+            autoFocus
+            ref={autoSelectText}
+          />
+          <AtomLabelEditButtonStyled
+            area="submit"
+            type="submit"
+            aria-label="Submit"
+          >
+            ✔️
+          </AtomLabelEditButtonStyled>
+          <AtomLabelEditButtonStyled
+            area="cancel"
+            type="button"
+            aria-label="Cancel"
+            onClick={onCancelClick}
+          >
+            ❌
+          </AtomLabelEditButtonStyled>
+
+          {Object.entries(greekLetters).map(([charName, greekChar]) => (
+            <AtomLabelEditButtonStyled
+              key={charName}
+              area={charName}
+              type="button"
+              onClick={onShortcut}
+            >
+              {greekChar}
+            </AtomLabelEditButtonStyled>
+          ))}
+
+          {Object.entries(primes).map(([primeName, primeChar]) => (
+            <AtomLabelEditButtonStyled
+              key={primeName}
+              area={primeName}
+              type="button"
+              onClick={onShortcut}
+            >
+              {primeChar}
+            </AtomLabelEditButtonStyled>
+          ))}
+        </AtomLabelEditFormStyled>
+      </AtomLabelEditDialogStyled>
+    </>
+  );
+}
+
+function autoSelectText(node: HTMLInputElement | null) {
+  node?.select();
+}

--- a/src/components/svg/svg_editor.styled.ts
+++ b/src/components/svg/svg_editor.styled.ts
@@ -21,11 +21,22 @@ export const primes = {
 };
 const primeNames = Object.keys(primes);
 
+export const AtomLabelEditDialogStyled = styled.dialog`
+  position: absolute;
+  padding: 0;
+  margin: 0;
+  border: none;
+
+  ::backdrop {
+    position: fixed;
+    inset: 0;
+    background: transparent;
+  }
+`;
+
 export const AtomLabelEditFormStyled = styled.form`
   --box-size: 24px;
 
-  position: absolute;
-  z-index: 1;
   line-height: 1;
   font-size: 16px;
   display: grid;


### PR DESCRIPTION
* refactor: move `AtomLabelEditForm` in his own file

Closes: https://github.com/zakodium-oss/react-ocl/issues/80