### PR TITLE
fix: handle undefined key in keyboard event

### DIFF
--- a/src/components/svg/editor/events_predicate.ts
+++ b/src/components/svg/editor/events_predicate.ts
@@ -16,8 +16,9 @@ export function isCleanEvent(event: KeyboardEvent) {
  */
 export function isQuickNumberingEvent(event: KeyboardEvent) {
   const isKeyQuote =
+    // Although event.key is typed to be a string, it can actually be undefined based on Sentry reports, in Chrome 145 and Safari 26
     // Normalized to handle different quote characters on different keyboards.
-    event.key.normalize() === "'" ||
+    event.key?.normalize() === "'" ||
     // Fallback on keyCode 222 and 52 which is known to be a quote. Even if it is a dead key
     event.keyCode === 222 ||
     event.keyCode === 52 ||


### PR DESCRIPTION
Based on sentry reports both in Chrome and Safari

Was not able to find out with what keyboard keys I can reproduce this.